### PR TITLE
Fixed XML syntax to comply with polycomConfig.xsd

### DIFF
--- a/AU-TONES.cfg
+++ b/AU-TONES.cfg
@@ -1,34 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <polycomConfig xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Config/polycomConfig.xsd">
-<AU-tones>
-<!-- Customise the tones for Oz -->
+  <!-- Customise the tones for Oz -->
   <tone>
     <tone.chord>
       <tone.chord.callProg>
-        <tone.chord.callProg.busyTone>
+        <tone.chord.callProg.busyTone tone.chord.callProg.busyTone.onDur="0" tone.chord.callProg.busyTone.offDur="0" tone.chord.callProg.busyTone.repeat="1">
           <tone.chord.callProg.busyTone.freq tone.chord.callProg.busyTone.freq.1="425" tone.chord.callProg.busyTone.freq.2="425" />
           <tone.chord.callProg.busyTone.level tone.chord.callProg.busyTone.level.1="-20" tone.chord.callProg.busyTone.level.2="-20" />
-          <tone.chord.callProg.busyTone.onDur tone.chord.callProg.busyTone.onDur="0" />
-          <tone.chord.callProg.busyTone.offDur tone.chord.callProg.busyTone.offDur="0" />
-          <tone.chord.callProg.busyTone.repeat tone.chord.callProg.busyTone.repeat="1" />
         </tone.chord.callProg.busyTone>
-        <tone.chord.callProg.reorder>
+        <tone.chord.callProg.reorder tone.chord.callProg.reorder.onDur="0" tone.chord.callProg.reorder.offDur="0" tone.chord.callProg.reorder.repeat="1">
           <tone.chord.callProg.reorder.freq tone.chord.callProg.reorder.freq.1="425" tone.chord.callProg.reorder.freq.2="425" />
           <tone.chord.callProg.reorder.level tone.chord.callProg.reorder.level.1="-20" tone.chord.callProg.reorder.level.2="-20" />
-          <tone.chord.callProg.reorder.onDur tone.chord.callProg.reorder.onDur="0" />
-          <tone.chord.callProg.reorder.offDur tone.chord.callProg.reorder.offDur="0" />
-          <tone.chord.callProg.reorder.repeat tone.chord.callProg.reorder.repeat="1" />
         </tone.chord.callProg.reorder>
         <tone.chord.callProg.dialTone>
           <tone.chord.callProg.dialTone.freq tone.chord.callProg.dialTone.freq.1="400" tone.chord.callProg.dialTone.freq.2="450" />
           <tone.chord.callProg.dialTone.level tone.chord.callProg.dialTone.level.1="-12" tone.chord.callProg.dialTone.level.2="-12" />
         </tone.chord.callProg.dialTone>
-        <tone.chord.callProg.ringback>
+        <tone.chord.callProg.ringback tone.chord.callProg.ringback.onDur="0" tone.chord.callProg.ringback.offDur="0" tone.chord.callProg.ringback.repeat="1">
           <tone.chord.callProg.ringback.freq tone.chord.callProg.ringback.freq.1="450" tone.chord.callProg.ringback.freq.2="400" />
           <tone.chord.callProg.ringback.level tone.chord.callProg.ringback.level.1="-20" tone.chord.callProg.ringback.level.2="-20" />
-          <tone.chord.callProg.ringback.onDur tone.chord.callProg.ringback.onDur="0" />
-          <tone.chord.callProg.ringback.offDur tone.chord.callProg.ringback.offDur="0" />
-          <tone.chord.callProg.ringback.repeat tone.chord.callProg.ringback.repeat="1" />
         </tone.chord.callProg.ringback>
       </tone.chord.callProg>
     </tone.chord>
@@ -47,6 +37,5 @@
         </se.pat.callProg.reorder>
       </se.pat.callProg>
     </se.pat>
-</se>
-</AU-tones>
+  </se>
 </polycomConfig>


### PR DESCRIPTION
![change-summary](https://user-images.githubusercontent.com/31003608/45801361-10d2e200-bcf7-11e8-875b-d05aabb84fc5.png)

1) removed XML Element [AU-Tones] as it is not allowed by the XSD definition
2) replaced XML Elements [onDur], [offDur] and [repeat] with XML Attributes with the same name (as per XSD)