### PR TITLE
wifi.cfg - Fixed XML to comply with polycomConfig.xsd

### DIFF
--- a/wifi.cfg
+++ b/wifi.cfg
@@ -5,13 +5,12 @@
   <!-- ================== Also https://github.com/greiginsydney/000000000000.cfg ================= -->
   <!-- ====================== This version last updated 19th September 2018 ======================= -->
   <!-- =========================================================================================== -->
-  <wifi>
-    <device>
-      <device.wifi device.wifi.enabled="1" device.wifi.enabled.set="1" device.wifi.dhcpEnabled="1" device.wifi.dhcpEnabled.set="1" device.wifi.ssid="##YourSSID##" device.wifi.ssid.set="1" device.wifi.securityMode="WPA2-PSK" device.wifi.securityMode.set="1" />
+  <device>
+    <device.wifi device.wifi.enabled="1" device.wifi.enabled.set="1" device.wifi.dhcpEnabled="1" device.wifi.dhcpEnabled.set="1" device.wifi.ssid="##YourSSID##" device.wifi.ssid.set="1" device.wifi.securityMode="WPA2-PSK" device.wifi.securityMode.set="1">
       <!-- Make sure you leave "radio.bandxxx.enable.set" 1 and then enable or disable the 2.4 or 5G bands with their "bandxxx.enable=" parameters. -->
-	    <!-- regulatoryDomain = 0 (Global), 1 (US) and 2 (EU) -->
+      <!-- regulatoryDomain = 0 (Global), 1 (US) and 2 (EU) -->
       <device.wifi.radio device.wifi.radio.regulatoryDomain="0" device.wifi.radio.regulatoryDomain.set="1" device.wifi.radio.band2_4GHz.enable="0" device.wifi.radio.band2_4GHz.enable.set="1" device.wifi.radio.band5GHz.enable="1" device.wifi.radio.band5GHz.enable.set="1" />
       <device.wifi.psk device.wifi.psk.keyType="1" device.wifi.psk.keyType.set="1" device.wifi.psk.key="##YourWi-FiPassword##" device.wifi.psk.key.set="1" />
-    </device>
-  </wifi>
+    </device.wifi>
+  </device>
 </polycomConfig>


### PR DESCRIPTION
1) removed 'wifi' element
2) moved 'device.wifi.radio' to become a child of 'device.wifi'
3) moved 'device.wifi.psk' to become a child of 'device.wifi'

This change will fix issue #2 (testing a link to the issue)

![wifi-change-summary](https://user-images.githubusercontent.com/31003608/45850970-c6e00f80-bd7b-11e8-9b7c-44c5af60c1dc.png)
